### PR TITLE
Added maven compiler and made README clearer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .idea/
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/README.md
+++ b/README.md
@@ -19,8 +19,16 @@
    - Flexible input: income, IRA balances, SSN income, estimate investment return etc.
    - Long-term Roth IRA growth simulation
 
-4. Usage:
-   
+4. Prerequisites:
+    - Java 17 SDK
+    - Maven
+
+5. Usage:
+     
+    Compile with `mvn clean package`
+    
+    Run using the following commands:
+ ```   
     IraRothPlanner 
    --ira={100000,180000}
    --age={60,59}
@@ -29,8 +37,13 @@
    --payTaxInIra=true
    --investRtn=0.05
    --yearBegin=2026
+```
+On windows:
+```
+java -jar .\IRA2RothOptimizer-1.0-SNAPSHOT.jar "--ira={100000,180000}" "--age={60,59}" --fixIncome=12000 "--ssnIncome={18000,28000}" --payTaxInIra=true --investRtn=0.05 --yearBegin=2026
+```
 
-7. Contributing:
+5. Contributing:
    
     Contributions are welcome!  
 Please open an issue or submit a pull request with improvements.  

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.example</groupId>
+    <groupId>com.liningalex.rothoptimizer</groupId>
     <artifactId>IRA2RothOptimizer</artifactId>
     <version>1.0-SNAPSHOT</version>
 
@@ -33,4 +33,60 @@
             <version>3.17.0</version> <!-- latest as of 2025 -->
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                    <manifest>
+                        <mainClass>com.liningalex.rothoptimizer.IraRothPlanner</mainClass>
+                    </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.liningalex.rothoptimizer.IraRothPlanner</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+    </plugins>
+    </build>
 </project>


### PR DESCRIPTION
I'm not a java guy but your original README is *confusing* as heck. Calling IraRothPlanner directly assumes that it compiles to a binary but afaik without some special packages and stuff (which I don't see in the pom file) it'll just compile to JAR. Also not sure how the output is supposed to look, ended up getting the following using the example args:
```
Year=2026, age=(60,59),ira=(86276,155298),roth=(12857,23143),rmd=(0,0),income=48000,medicare=0,tax=2323,taxRate=5
Year=2027, age=(61,60),ira=(76867,138360),roth=(26357,47443),rmd=(0,0),income=48000,medicare=0,tax=2323,taxRate=5
Year=2028, age=(62,61),ira=(66986,120576),roth=(40532,72958),rmd=(0,0),income=48000,medicare=0,tax=2323,taxRate=5
Year=2029, age=(63,62),ira=(56612,101902),roth=(55416,99749),rmd=(0,0),income=48000,medicare=0,tax=2323,taxRate=5
Year=2030, age=(64,63),ira=(45719,82295),roth=(71044,127879),rmd=(0,0),income=48000,medicare=0,tax=2323,taxRate=5
Year=2031, age=(65,64),ira=(31582,61707),roth=(87453,157416),rmd=(0,0),income=48000,medicare=2700,tax=2323,taxRate=5
Year=2032, age=(66,65),ira=(17452,36675),roth=(104013,189099),rmd=(0,0),income=48000,medicare=5400,tax=2323,taxRate=5
Year=2033, age=(67,66),ira=(9100,22097),roth=(115018,210750),rmd=(0,0),income=48000,medicare=5400,tax=2322,taxRate=5
Year=2034, age=(68,67),ira=(6855,20502),roth=(120768,221288),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2035, age=(69,68),ira=(4498,18827),roth=(126807,232352),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2036, age=(70,69),ira=(2023,17069),roth=(133147,243970),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2037, age=(71,70),ira=(0,15222),roth=(139228,256168),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2038, age=(72,71),ira=(0,13283),roth=(143490,268977),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2039, age=(73,72),ira=(0,11247),roth=(147964,282426),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2040, age=(74,73),ira=(0,8664),roth=(152662,296547),rmd=(0,445),income=58445,medicare=5400,tax=3668,taxRate=6
Year=2041, age=(75,74),ira=(0,6040),roth=(157596,311374),rmd=(0,356),income=58356,medicare=5400,tax=3655,taxRate=6
Year=2042, age=(76,75),ira=(0,3385),roth=(162775,326943),rmd=(0,257),income=58257,medicare=5400,tax=3641,taxRate=6
Year=2043, age=(77,76),ira=(0,704),roth=(168214,343290),rmd=(0,149),income=58149,medicare=5400,tax=3626,taxRate=6
Year=2044, age=(78,77),ira=(0,0),roth=(173925,358461),rmd=(0,32),income=58032,medicare=5400,tax=3609,taxRate=6
Year=2045, age=(79,78),ira=(0,0),roth=(179921,373685),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2046, age=(80,79),ira=(0,0),roth=(186217,389669),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2047, age=(81,80),ira=(0,0),roth=(192828,406452),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2048, age=(82,81),ira=(0,0),roth=(199769,424075),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2049, age=(83,82),ira=(0,0),roth=(207058,442579),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2050, age=(84,83),ira=(0,0),roth=(214711,462008),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2051, age=(85,84),ira=(0,0),roth=(222746,482408),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2052, age=(86,85),ira=(0,0),roth=(231183,503828),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2053, age=(87,86),ira=(0,0),roth=(240043,526320),rmd=(0,0),income=58000,medicare=5400,tax=3606,taxRate=6
Year=2054, age=(88,87),ira=(0,0),roth=(249345,549936),rmd=(0,0),income=40000,medicare=5400,tax=1363,taxRate=3
Year=2055, age=(89,88),ira=(0,0),roth=(259112,574732),rmd=(0,0),income=40000,medicare=5400,tax=1363,taxRate=3
income=48000,roth=875537,rmd=0,lastTax=0,totalTax=93598
```

